### PR TITLE
feat: GitHub commit status + Details link to build logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,1 @@
 # continuous-integration
-just a test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # continuous-integration
+just a test

--- a/src/main/java/BuildExecutor.java
+++ b/src/main/java/BuildExecutor.java
@@ -1,5 +1,9 @@
-import java.io.*;
-import java.nio.file.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 /**
  * This class is responsible for executing the core CI build steps.
@@ -44,15 +48,26 @@ public class BuildExecutor {
                 repoDir
         );
 
+
         // 5. Run Maven tests.
         // Maven returns exit code 0 on success, non-zero on failure.
+        String mvnCmd;
+        if (Files.exists(repoDir.toPath().resolve(isWindows() ? "mvnw.cmd" : "mvnw"))) {
+            mvnCmd = isWindows() ? "mvnw.cmd" : "./mvnw";
+        } else {
+            mvnCmd = isWindows() ? "mvn.cmd" : "mvn";
+        }
+
         int exitCode = runCommand(
-                new String[]{"mvn", "test"},
+                new String[]{mvnCmd, "test"},
                 repoDir
         );
 
         // Return true only if the build was successful.
         return exitCode == 0;
+    }
+    private boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
     }
 
     /**

--- a/src/main/java/BuildExecutor.java
+++ b/src/main/java/BuildExecutor.java
@@ -15,6 +15,9 @@ import java.nio.file.Path;
  */
 public class BuildExecutor {
 
+    // Stores the build id of the most recent build (used for linking logs in the CI server).
+    private volatile String lastBuildId = null;
+
     /**
      * Runs the CI build for a given repository and branch.
      *
@@ -29,10 +32,18 @@ public class BuildExecutor {
         Path tempDirectory = Files.createTempDirectory("ci-build-");
         System.out.println("[CI] Workspace: " + tempDirectory);
 
+        // Create a unique build id and prepare a log file for it.
+        // The log is stored at: builds/<buildId>/log.txt
+        lastBuildId = Long.toString(System.currentTimeMillis());
+        Path buildLogDir = Path.of("builds", lastBuildId);
+        Files.createDirectories(buildLogDir);
+        Path buildLogPath = buildLogDir.resolve("log.txt");
+
         // 2. Clone the repository into the temp directory.
         runCommand(
                 new String[]{"git", "clone", cloneUrl},
-                tempDirectory.toFile()
+                tempDirectory.toFile(),
+                buildLogPath
         );
 
         // 3. After cloning, find the repository directory.
@@ -45,7 +56,8 @@ public class BuildExecutor {
         // 4. Checkout the requested branch.
         runCommand(
                 new String[]{"git", "checkout", branch},
-                repoDir
+                repoDir,
+                buildLogPath
         );
 
 
@@ -60,12 +72,24 @@ public class BuildExecutor {
 
         int exitCode = runCommand(
                 new String[]{mvnCmd, "test"},
-                repoDir
+                repoDir,
+                buildLogPath
         );
 
         // Return true only if the build was successful.
         return exitCode == 0;
     }
+
+    /**
+     * Returns the build id of the most recent build.
+     * The corresponding log is available at: builds/<buildId>/log.txt
+     *
+     * @return last build id, or null if no build has been executed yet
+     */
+    public String getLastBuildId() {
+        return lastBuildId;
+    }
+
     private boolean isWindows() {
         return System.getProperty("os.name").toLowerCase().contains("win");
     }
@@ -77,11 +101,12 @@ public class BuildExecutor {
      *
      * @param cmd command and arguments (e.g. {"git", "clone", url})
      * @param dir working directory where the command is executed
+     * @param logFile file where build output is appended (builds/<buildId>/log.txt)
      * @return the exit code of the process
      * @throws IOException if the process cannot be started
      * @throws InterruptedException if the process is interrupted
      */
-    private int runCommand(String[] cmd, File dir)
+    private int runCommand(String[] cmd, File dir, Path logFile)
             throws IOException, InterruptedException {
 
         // Prepare the process builder with the given command.
@@ -102,11 +127,32 @@ public class BuildExecutor {
 
             String line;
             while ((line = r.readLine()) != null) {
-                System.out.println("[BUILD] " + line);
+                String out = "[BUILD] " + line;
+                System.out.println(out);
+                Files.writeString(logFile, out + System.lineSeparator(),
+                        java.nio.charset.StandardCharsets.UTF_8,
+                        java.nio.file.StandardOpenOption.CREATE,
+                        java.nio.file.StandardOpenOption.APPEND);
             }
         }
 
         // Wait for the process to finish and return its exit code.
-        return p.waitFor();
+        int exit = p.waitFor();
+        Files.writeString(logFile, "exitCode=" + exit + System.lineSeparator(),
+                java.nio.charset.StandardCharsets.UTF_8,
+                java.nio.file.StandardOpenOption.CREATE,
+                java.nio.file.StandardOpenOption.APPEND);
+        return exit;
+    }
+
+    // Backwards-compatible overload to keep existing behavior if needed elsewhere.
+    private int runCommand(String[] cmd, File dir)
+            throws IOException, InterruptedException {
+        Path fallbackLogDir = Path.of("builds", (lastBuildId == null ? "unknown" : lastBuildId));
+        try {
+            Files.createDirectories(fallbackLogDir);
+        } catch (IOException ignored) { }
+        Path fallbackLog = fallbackLogDir.resolve("log.txt");
+        return runCommand(cmd, dir, fallbackLog);
     }
 }

--- a/src/main/java/ContinuousIntegrationServer.java
+++ b/src/main/java/ContinuousIntegrationServer.java
@@ -108,7 +108,8 @@ public class ContinuousIntegrationServer extends AbstractHandler {
                     System.out.println("[NOTIFY] repository.full_name missing; cannot set commit status.");
                 } else {
                     GitHubStatusNotifier notifier = new GitHubStatusNotifier();
-                    notifier.setStatus(fullName, trigger.commitSha, result, result ? "build and tests passed" : "build or tests failed");
+                    String buildId = executor.getLastBuildId();
+                    notifier.setStatus(fullName, trigger.commitSha, result, result ? "build and tests passed" : "build or tests failed", buildId);
                 }
             } catch (Exception e) {
                 System.out.println("[NOTIFY] warning: could not set commit status: " + e.getMessage());

--- a/src/main/java/GitHubStatusNotifier.java
+++ b/src/main/java/GitHubStatusNotifier.java
@@ -65,6 +65,88 @@ public class GitHubStatusNotifier {
         }
     }
 
+    /**
+     * Same as setStatus(...) but also attaches a "Details" link pointing to the build log endpoint:
+     *   CI_PUBLIC_URL + "/build/" + buildId
+     *
+     * Requires environment variable:
+     *   CI_PUBLIC_URL = https://<your-ngrok-url> (or any public base URL to this CI server)
+     *
+     * If CI_PUBLIC_URL is not set (or invalid), it falls back to the normal status without target_url.
+     */
+    public void setStatus(String fullName, String sha, boolean success, String description, String buildId) throws Exception {
+        String publicBase = System.getenv("CI_PUBLIC_URL");
+
+        // If we cannot build a valid target_url, fall back to original method (unchanged behavior)
+        if (publicBase == null || publicBase.isBlank() || buildId == null || buildId.isBlank()) {
+            setStatus(fullName, sha, success, description);
+            return;
+        }
+
+        publicBase = publicBase.trim();
+
+        // Strip accidental quotes: set CI_PUBLIC_URL="https://...."
+        if (publicBase.length() >= 2 &&
+                ((publicBase.startsWith("\"") && publicBase.endsWith("\"")) ||
+                 (publicBase.startsWith("'") && publicBase.endsWith("'")))) {
+            publicBase = publicBase.substring(1, publicBase.length() - 1).trim();
+        }
+
+        // Must be http(s) or GitHub returns 422
+        if (!(publicBase.startsWith("http://") || publicBase.startsWith("https://"))) {
+            setStatus(fullName, sha, success, description);
+            return;
+        }
+
+        publicBase = publicBase.replaceAll("/+$", "");
+        String targetUrl = publicBase + "/build/" + buildId;
+
+        String token = System.getenv("GITHUB_TOKEN");
+        if (token == null || token.isBlank()) {
+            System.out.println("[NOTIFY] No GITHUB_TOKEN set; skipping GitHub status.");
+            return;
+        }
+
+        if (fullName == null || fullName.isBlank() || !fullName.contains("/")) {
+            System.out.println("[NOTIFY] Invalid repository full_name (expected owner/repo): " + fullName);
+            return;
+        }
+        if (sha == null || sha.isBlank()) {
+            System.out.println("[NOTIFY] Missing sha; cannot set status.");
+            return;
+        }
+
+        String state = success ? "success" : "failure";
+        String apiUrl = "https://api.github.com/repos/" + fullName + "/statuses/" + sha;
+
+        if (description == null) description = "";
+        if (description.length() > 120) description = description.substring(0, 120);
+
+        // context is what appears in GitHub checks UI
+        String json = "{"
+                + "\"state\":\"" + escapeJson(state) + "\","
+                + "\"context\":\"ci-server\","
+                + "\"description\":\"" + escapeJson(description) + "\","
+                + "\"target_url\":\"" + escapeJson(targetUrl) + "\""
+                + "}";
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(apiUrl))
+                .header("Accept", "application/vnd.github+json")
+                .header("Authorization", "Bearer " + token)
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+
+        if (resp.statusCode() >= 200 && resp.statusCode() < 300) {
+            System.out.println("[NOTIFY] Set GitHub commit status: " + state + " (with Details link)");
+        } else {
+            System.out.println("[NOTIFY] Failed to set status: " + resp.statusCode() + " body=" + resp.body());
+        }
+    }
+
     private static String escapeJson(String s) {
         return s.replace("\\", "\\\\").replace("\"", "\\\"");
     }

--- a/src/main/java/GitHubStatusNotifier.java
+++ b/src/main/java/GitHubStatusNotifier.java
@@ -1,0 +1,71 @@
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * Sends CI build result back to GitHub as a commit status (success/failure).
+ *
+ * Requires environment variable:
+ *   GITHUB_TOKEN = GitHub Personal Access Token with permission to set commit statuses.
+ */
+public class GitHubStatusNotifier {
+
+    private final HttpClient http = HttpClient.newHttpClient();
+
+    /**
+     * @param fullName    "owner/repo" (from webhook: repository.full_name)
+     * @param sha         commit SHA to set status on
+     * @param success     true => success, false => failure
+     * @param description short message shown in GitHub UI
+     */
+    public void setStatus(String fullName, String sha, boolean success, String description) throws Exception {
+        String token = System.getenv("GITHUB_TOKEN");
+        if (token == null || token.isBlank()) {
+            System.out.println("[NOTIFY] No GITHUB_TOKEN set; skipping GitHub status.");
+            return;
+        }
+
+        if (fullName == null || fullName.isBlank() || !fullName.contains("/")) {
+            System.out.println("[NOTIFY] Invalid repository full_name (expected owner/repo): " + fullName);
+            return;
+        }
+        if (sha == null || sha.isBlank()) {
+            System.out.println("[NOTIFY] Missing sha; cannot set status.");
+            return;
+        }
+
+        String state = success ? "success" : "failure";
+        String apiUrl = "https://api.github.com/repos/" + fullName + "/statuses/" + sha;
+
+        if (description == null) description = "";
+        if (description.length() > 120) description = description.substring(0, 120);
+
+        // context is what appears in GitHub checks UI
+        String json = "{"
+                + "\"state\":\"" + escapeJson(state) + "\","
+                + "\"context\":\"ci-server\","
+                + "\"description\":\"" + escapeJson(description) + "\""
+                + "}";
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(apiUrl))
+                .header("Accept", "application/vnd.github+json")
+                .header("Authorization", "Bearer " + token)
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+
+        if (resp.statusCode() >= 200 && resp.statusCode() < 300) {
+            System.out.println("[NOTIFY] Set GitHub commit status: " + state);
+        } else {
+            System.out.println("[NOTIFY] Failed to set status: " + resp.statusCode() + " body=" + resp.body());
+        }
+    }
+
+    private static String escapeJson(String s) {
+        return s.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}


### PR DESCRIPTION
PR Description:
**Implements GitHub Commit Status notifications (success/failure) after each CI run.

**Adds a build log endpoint GET /build/<buildId> so the “Details” link opens the build output.

**Stores build output under builds/<buildId>/log.txt.

**Adds target_url support in status payload using CI_PUBLIC_URL.

How to test:

**Set env vars: GITHUB_TOKEN and CI_PUBLIC_URL (ngrok https URL).

**Run CI server (mvn exec:java) and ngrok (ngrok http 8080).

**Push to the watched branch → GitHub show