### PR TITLE
feat: persistent build history and /builds listing (P7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # continuous-integration
+just a test

--- a/builds/1770760094129/log.txt
+++ b/builds/1770760094129/log.txt
@@ -1,0 +1,48 @@
+[BUILD] Cloning into 'continuous-integration'...
+exitCode=0
+[BUILD] branch 'issue/p7' set up to track 'origin/issue/p7'.
+[BUILD] Switched to a new branch 'issue/p7'
+exitCode=0
+[BUILD] [INFO] Scanning for projects...
+[BUILD] [INFO] 
+[BUILD] [INFO] ----------------< se.kth.dd2480:continuous-integration >----------------
+[BUILD] [INFO] Building continuous-integration 1.0-SNAPSHOT
+[BUILD] [INFO]   from pom.xml
+[BUILD] [INFO] --------------------------------[ jar ]---------------------------------
+[BUILD] [INFO] 
+[BUILD] [INFO] --- resources:3.3.1:resources (default-resources) @ continuous-integration ---
+[BUILD] [INFO] skip non existing resourceDirectory C:\Users\moham\AppData\Local\Temp\ci-build-14579635795773634977\continuous-integration\src\main\resources
+[BUILD] [INFO] 
+[BUILD] [INFO] --- compiler:3.11.0:compile (default-compile) @ continuous-integration ---
+[BUILD] [INFO] Changes detected - recompiling the module! :source
+[BUILD] [INFO] Compiling 4 source files with javac [debug target 11] to target\classes
+[BUILD] [WARNING] system modules path not set in conjunction with -source 11
+[BUILD] [INFO] 
+[BUILD] [INFO] --- resources:3.3.1:testResources (default-testResources) @ continuous-integration ---
+[BUILD] [INFO] skip non existing resourceDirectory C:\Users\moham\AppData\Local\Temp\ci-build-14579635795773634977\continuous-integration\src\test\resources
+[BUILD] [INFO] 
+[BUILD] [INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ continuous-integration ---
+[BUILD] [INFO] Changes detected - recompiling the module! :dependency
+[BUILD] [INFO] Compiling 1 source file with javac [debug target 11] to target\test-classes
+[BUILD] [WARNING] system modules path not set in conjunction with -source 11
+[BUILD] [INFO] 
+[BUILD] [INFO] --- surefire:3.2.5:test (default-test) @ continuous-integration ---
+[BUILD] [INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
+[BUILD] [INFO] 
+[BUILD] [INFO] -------------------------------------------------------
+[BUILD] [INFO]  T E S T S
+[BUILD] [INFO] -------------------------------------------------------
+[BUILD] [INFO] Running GitHubPayloadParserTest
+[BUILD] [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.200 s -- in GitHubPayloadParserTest
+[BUILD] [INFO] 
+[BUILD] [INFO] Results:
+[BUILD] [INFO] 
+[BUILD] [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
+[BUILD] [INFO] 
+[BUILD] [INFO] ------------------------------------------------------------------------
+[BUILD] [INFO] BUILD SUCCESS
+[BUILD] [INFO] ------------------------------------------------------------------------
+[BUILD] [INFO] Total time:  2.684 s
+[BUILD] [INFO] Finished at: 2026-02-10T22:48:19+01:00
+[BUILD] [INFO] ------------------------------------------------------------------------
+exitCode=0

--- a/builds/1770760094129/meta.json
+++ b/builds/1770760094129/meta.json
@@ -1,0 +1,10 @@
+{
+  "buildId" : "1770760094129",
+  "branch" : "issue/p7",
+  "commitSha" : "d777bd08cc6303673ff6a92577722eef9beb963a",
+  "repoFullName" : "IK1203-Group11/continuous-integration",
+  "status" : "success",
+  "startedAt" : "2026-02-10T21:48:14.129941Z",
+  "finishedAt" : "2026-02-10T21:48:19.592402400Z",
+  "logUrl" : "/build/1770760094129"
+}

--- a/builds/1770805903238/log.txt
+++ b/builds/1770805903238/log.txt
@@ -1,0 +1,48 @@
+[BUILD] Cloning into 'continuous-integration'...
+exitCode=0
+[BUILD] branch 'ReadMe/setup' set up to track 'origin/ReadMe/setup'.
+[BUILD] Switched to a new branch 'ReadMe/setup'
+exitCode=0
+[BUILD] [INFO] Scanning for projects...
+[BUILD] [INFO] 
+[BUILD] [INFO] ----------------< se.kth.dd2480:continuous-integration >----------------
+[BUILD] [INFO] Building continuous-integration 1.0-SNAPSHOT
+[BUILD] [INFO]   from pom.xml
+[BUILD] [INFO] --------------------------------[ jar ]---------------------------------
+[BUILD] [INFO] 
+[BUILD] [INFO] --- resources:3.3.1:resources (default-resources) @ continuous-integration ---
+[BUILD] [INFO] skip non existing resourceDirectory C:\Users\moham\AppData\Local\Temp\ci-build-13916374076965494466\continuous-integration\src\main\resources
+[BUILD] [INFO] 
+[BUILD] [INFO] --- compiler:3.11.0:compile (default-compile) @ continuous-integration ---
+[BUILD] [INFO] Changes detected - recompiling the module! :source
+[BUILD] [INFO] Compiling 3 source files with javac [debug target 11] to target\classes
+[BUILD] [WARNING] system modules path not set in conjunction with -source 11
+[BUILD] [INFO] 
+[BUILD] [INFO] --- resources:3.3.1:testResources (default-testResources) @ continuous-integration ---
+[BUILD] [INFO] skip non existing resourceDirectory C:\Users\moham\AppData\Local\Temp\ci-build-13916374076965494466\continuous-integration\src\test\resources
+[BUILD] [INFO] 
+[BUILD] [INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ continuous-integration ---
+[BUILD] [INFO] Changes detected - recompiling the module! :dependency
+[BUILD] [INFO] Compiling 1 source file with javac [debug target 11] to target\test-classes
+[BUILD] [WARNING] system modules path not set in conjunction with -source 11
+[BUILD] [INFO] 
+[BUILD] [INFO] --- surefire:3.2.5:test (default-test) @ continuous-integration ---
+[BUILD] [INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
+[BUILD] [INFO] 
+[BUILD] [INFO] -------------------------------------------------------
+[BUILD] [INFO]  T E S T S
+[BUILD] [INFO] -------------------------------------------------------
+[BUILD] [INFO] Running GitHubPayloadParserTest
+[BUILD] [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.281 s -- in GitHubPayloadParserTest
+[BUILD] [INFO] 
+[BUILD] [INFO] Results:
+[BUILD] [INFO] 
+[BUILD] [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
+[BUILD] [INFO] 
+[BUILD] [INFO] ------------------------------------------------------------------------
+[BUILD] [INFO] BUILD SUCCESS
+[BUILD] [INFO] ------------------------------------------------------------------------
+[BUILD] [INFO] Total time:  7.802 s
+[BUILD] [INFO] Finished at: 2026-02-11T11:31:57+01:00
+[BUILD] [INFO] ------------------------------------------------------------------------
+exitCode=0

--- a/builds/1770805903238/meta.json
+++ b/builds/1770805903238/meta.json
@@ -1,0 +1,10 @@
+{
+  "buildId" : "1770805903238",
+  "branch" : "ReadMe/setup",
+  "commitSha" : "f391ad3744b7d4812d7520dd8328b5ebe465d905",
+  "repoFullName" : "IK1203-Group11/continuous-integration",
+  "status" : "success",
+  "startedAt" : "2026-02-11T10:31:43.236052200Z",
+  "finishedAt" : "2026-02-11T10:31:57.228959900Z",
+  "logUrl" : "/build/1770805903238"
+}

--- a/builds/1770813259651/log.txt
+++ b/builds/1770813259651/log.txt
@@ -1,0 +1,48 @@
+[BUILD] Cloning into 'continuous-integration'...
+exitCode=0
+[BUILD] Your branch is up to date with 'origin/main'.
+[BUILD] Already on 'main'
+exitCode=0
+[BUILD] [INFO] Scanning for projects...
+[BUILD] [INFO] 
+[BUILD] [INFO] ----------------< se.kth.dd2480:continuous-integration >----------------
+[BUILD] [INFO] Building continuous-integration 1.0-SNAPSHOT
+[BUILD] [INFO]   from pom.xml
+[BUILD] [INFO] --------------------------------[ jar ]---------------------------------
+[BUILD] [INFO] 
+[BUILD] [INFO] --- resources:3.3.1:resources (default-resources) @ continuous-integration ---
+[BUILD] [INFO] skip non existing resourceDirectory C:\Users\moham\AppData\Local\Temp\ci-build-5869437340217787569\continuous-integration\src\main\resources
+[BUILD] [INFO] 
+[BUILD] [INFO] --- compiler:3.11.0:compile (default-compile) @ continuous-integration ---
+[BUILD] [INFO] Changes detected - recompiling the module! :source
+[BUILD] [INFO] Compiling 4 source files with javac [debug target 11] to target\classes
+[BUILD] [WARNING] system modules path not set in conjunction with -source 11
+[BUILD] [INFO] 
+[BUILD] [INFO] --- resources:3.3.1:testResources (default-testResources) @ continuous-integration ---
+[BUILD] [INFO] skip non existing resourceDirectory C:\Users\moham\AppData\Local\Temp\ci-build-5869437340217787569\continuous-integration\src\test\resources
+[BUILD] [INFO] 
+[BUILD] [INFO] --- compiler:3.11.0:testCompile (default-testCompile) @ continuous-integration ---
+[BUILD] [INFO] Changes detected - recompiling the module! :dependency
+[BUILD] [INFO] Compiling 1 source file with javac [debug target 11] to target\test-classes
+[BUILD] [WARNING] system modules path not set in conjunction with -source 11
+[BUILD] [INFO] 
+[BUILD] [INFO] --- surefire:3.2.5:test (default-test) @ continuous-integration ---
+[BUILD] [INFO] Using auto detected provider org.apache.maven.surefire.junit4.JUnit4Provider
+[BUILD] [INFO] 
+[BUILD] [INFO] -------------------------------------------------------
+[BUILD] [INFO]  T E S T S
+[BUILD] [INFO] -------------------------------------------------------
+[BUILD] [INFO] Running GitHubPayloadParserTest
+[BUILD] [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.632 s -- in GitHubPayloadParserTest
+[BUILD] [INFO] 
+[BUILD] [INFO] Results:
+[BUILD] [INFO] 
+[BUILD] [INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0
+[BUILD] [INFO] 
+[BUILD] [INFO] ------------------------------------------------------------------------
+[BUILD] [INFO] BUILD SUCCESS
+[BUILD] [INFO] ------------------------------------------------------------------------
+[BUILD] [INFO] Total time:  8.466 s
+[BUILD] [INFO] Finished at: 2026-02-11T13:34:34+01:00
+[BUILD] [INFO] ------------------------------------------------------------------------
+exitCode=0

--- a/builds/1770813259651/meta.json
+++ b/builds/1770813259651/meta.json
@@ -1,0 +1,10 @@
+{
+  "buildId" : "1770813259651",
+  "branch" : "main",
+  "commitSha" : "88e286eee9be071587d693fad41ec2a805e4729e",
+  "repoFullName" : "IK1203-Group11/continuous-integration",
+  "status" : "success",
+  "startedAt" : "2026-02-11T12:34:19.646506Z",
+  "finishedAt" : "2026-02-11T12:34:34.521252300Z",
+  "logUrl" : "/build/1770813259651"
+}

--- a/builds/1770813706017/log.txt
+++ b/builds/1770813706017/log.txt
@@ -1,0 +1,162 @@
+[BUILD] Cloning into 'continuous-integration'...
+exitCode=0
+[BUILD] branch 'issue/6' set up to track 'origin/issue/6'.
+[BUILD] Switched to a new branch 'issue/6'
+exitCode=0
+[BUILD] [INFO] Scanning for projects...
+[BUILD] [INFO] 
+[BUILD] [INFO] ----------------< se.kth.dd2480:continuous-integration >----------------
+[BUILD] [INFO] Building continuous-integration 1.0-SNAPSHOT
+[BUILD] [INFO]   from pom.xml
+[BUILD] [INFO] --------------------------------[ jar ]---------------------------------
+[BUILD] [INFO] 
+[BUILD] [INFO] --- resources:3.3.1:resources (default-resources) @ continuous-integration ---
+[BUILD] [INFO] skip non existing resourceDirectory C:\Users\moham\AppData\Local\Temp\ci-build-2150602669502591641\continuous-integration\src\main\resources
+[BUILD] [INFO] 
+[BUILD] [INFO] --- compiler:3.11.0:compile (default-compile) @ continuous-integration ---
+[BUILD] [INFO] Changes detected - recompiling the module! :source
+[BUILD] [INFO] Compiling 4 source files with javac [debug target 11] to target\classes
+[BUILD] [INFO] -------------------------------------------------------------
+[BUILD] [WARNING] COMPILATION WARNING : 
+[BUILD] [INFO] -------------------------------------------------------------
+[BUILD] [WARNING] system modules path not set in conjunction with -source 11
+[BUILD] [INFO] 1 warning
+[BUILD] [INFO] -------------------------------------------------------------
+[BUILD] [INFO] -------------------------------------------------------------
+[BUILD] [ERROR] COMPILATION ERROR : 
+[BUILD] [INFO] -------------------------------------------------------------
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[1,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[3,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[4,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[5,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[6,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[8,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[9,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[10,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[11,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[12,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[13,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[25,1] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[25,13] > expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[27,5] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[28,1] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[31,1] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[31,13] <identifier> expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[61,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[61,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[61,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[63,9] > or ',' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[64,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[64,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[64,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[64,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[78,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[78,4] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[78,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[78,13] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[127,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[127,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[127,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[128,1] > or ',' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[128,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[128,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[128,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[129,13] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[156,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[156,4] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[156,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[156,13] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[189,1] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[189,13] > expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[192,5] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[192,77] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[194,65] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[216,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[216,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[216,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[217,17] > or ',' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[220,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[220,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[220,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[220,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[221,23] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[227,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[227,4] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[227,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[227,13] ';' expected
+[BUILD] [INFO] 59 errors 
+[BUILD] [INFO] -------------------------------------------------------------
+[BUILD] [INFO] ------------------------------------------------------------------------
+[BUILD] [INFO] BUILD FAILURE
+[BUILD] [INFO] ------------------------------------------------------------------------
+[BUILD] [INFO] Total time:  3.159 s
+[BUILD] [INFO] Finished at: 2026-02-11T13:41:54+01:00
+[BUILD] [INFO] ------------------------------------------------------------------------
+[BUILD] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.11.0:compile (default-compile) on project continuous-integration: Compilation failure: Compilation failure: 
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[1,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[3,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[4,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[5,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[6,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[8,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[9,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[10,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[11,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[12,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[13,1] class, interface, or enum expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[25,1] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[25,13] > expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[27,5] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[28,1] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[31,1] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[31,13] <identifier> expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[61,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[61,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[61,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[63,9] > or ',' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[64,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[64,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[64,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[64,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[78,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[78,4] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[78,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[78,13] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[127,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[127,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[127,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[128,1] > or ',' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[128,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[128,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[128,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[129,13] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[156,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[156,4] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[156,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[156,13] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[189,1] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[189,13] > expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[192,5] illegal start of type
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[192,77] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[194,65] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[216,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[216,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[216,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[217,17] > or ',' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[220,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[220,3] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[220,5] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[220,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[221,23] ';' expected
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[227,1] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[227,4] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[227,7] illegal start of expression
+[BUILD] [ERROR] /C:/Users/moham/AppData/Local/Temp/ci-build-2150602669502591641/continuous-integration/src/main/java/BuildExecutor.java:[227,13] ';' expected
+[BUILD] [ERROR] -> [Help 1]
+[BUILD] [ERROR] 
+[BUILD] [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
+[BUILD] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
+[BUILD] [ERROR] 
+[BUILD] [ERROR] For more information about the errors and possible solutions, please read the following articles:
+[BUILD] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
+exitCode=1

--- a/builds/1770813706017/meta.json
+++ b/builds/1770813706017/meta.json
@@ -1,0 +1,10 @@
+{
+  "buildId" : "1770813706017",
+  "branch" : "issue/6",
+  "commitSha" : "ed1301c373115f0afb08a75fbadace16f9cb7882",
+  "repoFullName" : "IK1203-Group11/continuous-integration",
+  "status" : "failure",
+  "startedAt" : "2026-02-11T12:41:46.015323500Z",
+  "finishedAt" : "2026-02-11T12:41:55.093578200Z",
+  "logUrl" : "/build/1770813706017"
+}

--- a/src/main/java/ContinuousIntegrationServer.java
+++ b/src/main/java/ContinuousIntegrationServer.java
@@ -122,7 +122,7 @@ public class ContinuousIntegrationServer extends AbstractHandler {
             } else {
                 html.append("<ul>");
                 for (BuildMeta m : metas) {
-                    String icon = "success".equals(m.status) ? "✅" : "❌";
+                    String icon = "success".equals(m.status) ? "success" : "fail";
                     String shortSha = (m.commitSha == null) ? "" : m.commitSha.substring(0, Math.min(12, m.commitSha.length()));
                     html.append("<li>")
                             .append(icon).append(" ")


### PR DESCRIPTION
PR Description:

-Persists each build under builds/<buildId>/ with:

-log.txt (build output)

-meta.json (branch, commit SHA, timestamps, status)

-Adds GET /builds endpoint to list all past builds (clickable log links).

-Build history is stored on disk and remains available after server restart.

How to test:

-Run server (mvn exec:java) and trigger at least 2 pushes.

-Open http://localhost:8080/builds (or public URL) → builds are listed.

-Click log → opens /build/<buildId> and shows output.